### PR TITLE
feat: 누락 및 예외 처리 오류 수정

### DIFF
--- a/src/main/java/Momentum/heatcaution/controller/ProtectorController.java
+++ b/src/main/java/Momentum/heatcaution/controller/ProtectorController.java
@@ -1,9 +1,9 @@
 package Momentum.heatcaution.controller;
 
 import Momentum.heatcaution.dto.ProtectorDto;
+import Momentum.heatcaution.exception.LoginRequiredException;
 import Momentum.heatcaution.service.ProtectorService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,7 +30,7 @@ public class ProtectorController {
     private String getUsernameFromSession(HttpSession session) {
         String username = (String) session.getAttribute("loggedInUser");
         if (username == null) {
-            throw new IllegalStateException("로그인이 필요합니다.");
+            throw new LoginRequiredException();
         }
         return username;
     }

--- a/src/main/java/Momentum/heatcaution/exception/GlobalExceptionHandler.java
+++ b/src/main/java/Momentum/heatcaution/exception/GlobalExceptionHandler.java
@@ -46,13 +46,26 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of("PASSWORD_MISMATCH", e.getMessage()));
     }
-    //관리자가 아닐 경우
+    //로그인 필요 예외를 처리 -> 401
+    @ExceptionHandler(LoginRequiredException.class)
+    public ResponseEntity<ErrorResponse> handleLoginRequired(LoginRequiredException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponse.of("LOGIN_REQUIRED", e.getMessage()));
+    }
+
+    //보호자 등록 한도 초과 예외를 처리 -> 400
+    @ExceptionHandler(ProtectorLimitExceededException.class)
+    public ResponseEntity<ErrorResponse> handleProtectorLimitExceeded(ProtectorLimitExceededException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of("LIMIT_EXCEEDED", e.getMessage()));
+    }
+
+    //'관리자 권한' 문제처럼 금지된 접근에만 사용
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<ErrorResponse> handleIllegalState(IllegalStateException e) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(ErrorResponse.of("NOT_ADMIN", e.getMessage()));
+                .body(ErrorResponse.of("FORBIDDEN_ACCESS", e.getMessage()));
     }
-
 
     // NullPointer, 런타임 오류... 여러 오류 -> 500
     @ExceptionHandler(Exception.class)

--- a/src/main/java/Momentum/heatcaution/exception/LoginRequiredException.java
+++ b/src/main/java/Momentum/heatcaution/exception/LoginRequiredException.java
@@ -1,0 +1,7 @@
+package Momentum.heatcaution.exception;
+
+public class LoginRequiredException extends RuntimeException {
+    public LoginRequiredException() {
+        super("로그인이 필요합니다.");
+    }
+}

--- a/src/main/java/Momentum/heatcaution/exception/ProtectorLimitExceededException.java
+++ b/src/main/java/Momentum/heatcaution/exception/ProtectorLimitExceededException.java
@@ -1,0 +1,7 @@
+package Momentum.heatcaution.exception;
+
+public class ProtectorLimitExceededException extends RuntimeException {
+    public ProtectorLimitExceededException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/Momentum/heatcaution/service/ProtectorService.java
+++ b/src/main/java/Momentum/heatcaution/service/ProtectorService.java
@@ -103,6 +103,7 @@ public class ProtectorService {
         ProtectorDto dto = new ProtectorDto();
         dto.setId(protector.getId());
         dto.setName(protector.getName());
+        dto.setRelation(protector.getRelation());
         dto.setPhone(protector.getPhone());
         return dto;
     }

--- a/src/main/java/Momentum/heatcaution/service/ProtectorService.java
+++ b/src/main/java/Momentum/heatcaution/service/ProtectorService.java
@@ -3,6 +3,7 @@ package Momentum.heatcaution.service;
 import Momentum.heatcaution.dto.ProtectorDto;
 import Momentum.heatcaution.entity.Protector;
 import Momentum.heatcaution.entity.User;
+import Momentum.heatcaution.exception.ProtectorLimitExceededException;
 import Momentum.heatcaution.repository.ProtectorRepository;
 import Momentum.heatcaution.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -33,7 +34,7 @@ public class ProtectorService {
         User user = findUserByUsername(username);
 
         if (protectorRepository.countByUser(user) >= MAX_PROTECTOR_COUNT) {
-            throw new IllegalStateException("보호자는 최대 " + MAX_PROTECTOR_COUNT + "명까지 등록할 수 있습니다.");
+            throw new ProtectorLimitExceededException("보호자는 최대 " + MAX_PROTECTOR_COUNT + "명까지 등록할 수 있습니다.");
         }
 
         Protector protector = new Protector();


### PR DESCRIPTION
protector의 relation필드가 json 반환값에서는 null로 출력되고, DB에선 정상적으로 출력되던 현상을 수정하였습니다.
=> entity -> dto 변환 과정에서 relation필드 누락이 있어서 추가하였습니다.

IllegalStateException이 발생할경우 NOT_ADMIN일 경우로 전부 처리가 되었는데
한 명의 유저가 5명의 보호자를 이미 생성중인데 더 추가하려고 하는 경우의 예외처리를 ProtectorLimitExceededException을 만들어서 추가로 handling하였습니다.