### PR TITLE
feat: username update API 구현

### DIFF
--- a/src/main/java/Momentum/heatcaution/controller/UserController.java
+++ b/src/main/java/Momentum/heatcaution/controller/UserController.java
@@ -2,6 +2,7 @@ package Momentum.heatcaution.controller;
 
 import Momentum.heatcaution.dto.LoginRequest;
 import Momentum.heatcaution.dto.RegisterRequest;
+import Momentum.heatcaution.exception.LoginRequiredException;
 import Momentum.heatcaution.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -13,6 +14,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @Tag(name = "User API", description = "일반 사용자용 API (회원가입, 로그인, 로그아웃)")
 @RestController
@@ -60,5 +63,14 @@ public class UserController {
             return ResponseEntity.ok(logoutMessage);
         }
         return ResponseEntity.ok("로그아웃할 세션이 없습니다.");
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<?> getMyUsername(HttpSession session) {
+        String username = (String) session.getAttribute("loggedInUser");
+        if (username == null) {
+            throw new LoginRequiredException();
+        }
+        return ResponseEntity.ok(Map.of("username", username));
     }
 }

--- a/src/main/java/Momentum/heatcaution/controller/UserController.java
+++ b/src/main/java/Momentum/heatcaution/controller/UserController.java
@@ -66,15 +66,6 @@ public class UserController {
         return ResponseEntity.ok("로그아웃할 세션이 없습니다.");
     }
 
-    @GetMapping("/me")
-    public ResponseEntity<?> getMyUsername(HttpSession session) {
-        String username = (String) session.getAttribute("loggedInUser");
-        if (username == null) {
-            throw new LoginRequiredException();
-        }
-        return ResponseEntity.ok(Map.of("username", username));
-    }
-
     @PatchMapping("/username")
     public ResponseEntity<?> updateUsername(@RequestBody @Valid UpdateUsernameRequest request, HttpSession session) {
         String username = (String) session.getAttribute("loggedInUser");

--- a/src/main/java/Momentum/heatcaution/controller/UserController.java
+++ b/src/main/java/Momentum/heatcaution/controller/UserController.java
@@ -66,6 +66,13 @@ public class UserController {
         return ResponseEntity.ok("로그아웃할 세션이 없습니다.");
     }
 
+    @Operation(summary = "내 아이디 변경", description = "현재 로그인된 사용자의 아이디(username)를 새로운 값으로 변경합니다. 변경 후에는 세션 정보도 갱신됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "아이디 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "입력값이 비어있음"),
+            @ApiResponse(responseCode = "401", description = "로그인 필요"),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 아이디 (Conflict)")
+    })
     @PatchMapping("/username")
     public ResponseEntity<?> updateUsername(@RequestBody @Valid UpdateUsernameRequest request, HttpSession session) {
         String username = (String) session.getAttribute("loggedInUser");

--- a/src/main/java/Momentum/heatcaution/controller/UserController.java
+++ b/src/main/java/Momentum/heatcaution/controller/UserController.java
@@ -2,6 +2,7 @@ package Momentum.heatcaution.controller;
 
 import Momentum.heatcaution.dto.LoginRequest;
 import Momentum.heatcaution.dto.RegisterRequest;
+import Momentum.heatcaution.dto.UpdateUsernameRequest;
 import Momentum.heatcaution.exception.LoginRequiredException;
 import Momentum.heatcaution.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -72,5 +73,19 @@ public class UserController {
             throw new LoginRequiredException();
         }
         return ResponseEntity.ok(Map.of("username", username));
+    }
+
+    @PatchMapping("/username")
+    public ResponseEntity<?> updateUsername(@RequestBody @Valid UpdateUsernameRequest request, HttpSession session) {
+        String username = (String) session.getAttribute("loggedInUser");
+        if (username == null) {
+            throw new LoginRequiredException();
+        }
+        //DB와 엔티티 username 변경
+        String updatedUsername = userService.updateUsername(username, request.newUsername());
+        //세션에 저장된 username정보 변경
+        session.setAttribute("loggedInUser", updatedUsername);
+
+        return ResponseEntity.ok("아이디가 성공적으로 변경되었습니다.");
     }
 }

--- a/src/main/java/Momentum/heatcaution/dto/UpdateUsernameRequest.java
+++ b/src/main/java/Momentum/heatcaution/dto/UpdateUsernameRequest.java
@@ -1,0 +1,11 @@
+package Momentum.heatcaution.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "사용자 아이디 변경 요청 DTO")
+public record UpdateUsernameRequest (
+    @NotBlank(message = "새로운 아이디를 입력해주세요.")
+    @Schema(description = "변경할 새로운 아이디", example = "new_testuser")
+    String newUsername
+) {}

--- a/src/main/java/Momentum/heatcaution/entity/User.java
+++ b/src/main/java/Momentum/heatcaution/entity/User.java
@@ -42,6 +42,10 @@ public class User {
         this.role = (role != null ? role : Role.USER); // 전달값 없으면 USER
     }
 
+    // username 업데이트
+    public void updateUsername(String newUsername) {
+        this.username = newUsername;
+    }
 
     public enum Role {
         USER, ADMIN

--- a/src/main/java/Momentum/heatcaution/service/UserService.java
+++ b/src/main/java/Momentum/heatcaution/service/UserService.java
@@ -49,4 +49,19 @@ public class UserService {
     }
 
 
+    @Transactional
+    public String updateUsername(String currentUsername, String newUsername) {
+        //새로운 아이디가 이미 존재하는지
+        if (userRepository.existsByUsername(newUsername)) {
+            throw new IllegalStateException("이미 사용 중인 아이디 입니다.");
+        }
+        //현재 사용자 DB 조회
+        User user = userRepository.findByUsername(currentUsername)
+                .orElseThrow(UserNotFoundException::new);
+
+        //User 엔티티의 username 변경
+        user.updateUsername(newUsername);
+
+        return user.getUsername();
+    }
 }


### PR DESCRIPTION
## 📄 PR 요약
'User' 엔티티의 username(로그인시 필요 ID) 필드를 업데이트 하는 API 구현

## ✨ 주요 변경 사항
'User' 엔티티에 updateUsername 메서드 추가
'UpdateUsernameRequest' DTO 생성, 새로운 아이디를 담을 DTO 생성
'UserService'에 updateUsername 메서드 추가
'UserController' 에 'PATCH /api/users/username' 엔드포인트 구현
Swagger 추가
