### PR TITLE
feat: 워치데이터 관련 추가 엔티티 생성

### DIFF
--- a/src/main/java/Momentum/heatcaution/entity/Ai.java
+++ b/src/main/java/Momentum/heatcaution/entity/Ai.java
@@ -5,32 +5,29 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "health_data")
-public class HealthData {
+@Table(name = "ai_predictions")
+public class Ai {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long id; // PK
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user; // 유저 id (FK)
 
-    private Double heartRate; // 심박수
-    private Double bodyTemperature; // 체온
-    private LocalDateTime measurementTime; // 측정 시간
+    private Double heartRate;
+    private LocalDateTime predictionTime = LocalDateTime.now(); // *시간은 상세페이지를 위해 필요함*
 
-    public HealthData(User user, Double heartRate, Double bodyTemperature, LocalDateTime measurementTime) {
+    public Ai(User user, Double heartRate, LocalDateTime predictionTime) {
         this.user = user;
         this.heartRate = heartRate;
-        this.bodyTemperature = bodyTemperature;
-        this.measurementTime = measurementTime;
+        if (predictionTime != null) this.predictionTime = predictionTime;
     }
 }
 

--- a/src/main/java/Momentum/heatcaution/entity/HealthData.java
+++ b/src/main/java/Momentum/heatcaution/entity/HealthData.java
@@ -1,0 +1,52 @@
+package Momentum.heatcaution.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "health_data")
+public class HealthData {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // FK → users.id
+
+    @Column(name = "heart_rate")
+    private Double heartRate;
+
+    @Column(name = "body_temperature")
+    private Double bodyTemperature;
+
+    @Column(name = "measurement_time", nullable = false)
+    private LocalDateTime measurementTime;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public HealthData(User user, Double heartRate, Double bodyTemperature, LocalDateTime measurementTime) {
+        this.user = user;
+        this.heartRate = heartRate;
+        this.bodyTemperature = bodyTemperature;
+        this.measurementTime = measurementTime;
+    }
+}
+
+

--- a/src/main/java/Momentum/heatcaution/entity/User.java
+++ b/src/main/java/Momentum/heatcaution/entity/User.java
@@ -23,6 +23,8 @@ public class User {
     private String name;
     private LocalDate birth;
     private String phone;
+    private Boolean hasWatch = false;
+    private LocalDateTime updateAt;
 
     @Enumerated(EnumType.STRING)
     private Role role;


### PR DESCRIPTION
### 작업 개요
---
- 워치 데이터를 받아오기 위한 추가 엔티티 생성
1. Ai
2. HealthData
### 변경 사항
---
- 기존 user에 hasWatch, updataAt